### PR TITLE
Add offline/online setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@
 4. [Solidity Code Safety](#solidity-code-safety)
 5. [Contributors](#contributors)
 6. [Socials](#socials)
-7. [Release Notes](#release-notes)
-8. [Listings](#listings)
-9. [License](#license)
+7. [Local Setup](#local-setup)
+8. [Release Notes](#release-notes)
+9. [Listings](#listings)
+10. [License](#license)
 
 ---
 
@@ -50,6 +51,23 @@ The safety of our Solidity code is paramount. The contract is built using OpenZe
 - [Twitter](https://twitter.com/badideaai)
 - [Facebook](https://www.facebook.com/groups/badideaai/)
 - [CoinMarketCap](https://coinmarketcap.com/community/profile/BAD_IDEA_AI/)
+
+---
+
+## Local Setup
+Use the `setup.sh` script to prepare your environment. The script supports two
+modes:
+
+```bash
+# Online mode (default)
+./setup.sh --online
+
+# Offline mode (uses cached npm packages)
+./setup.sh --offline
+```
+
+If `OFFLINE=1` is set in the environment, the script automatically runs in
+offline mode.
 
 ---
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Setup script for Bad-Idea-AI environment
+# Usage: ./setup.sh [--offline|--online]
+# Defaults to online mode if not specified.
+
+set -euo pipefail
+
+MODE="online"
+for arg in "$@"; do
+  case "$arg" in
+    --offline)
+      MODE="offline"
+      ;;
+    --online)
+      MODE="online"
+      ;;
+  esac
+ done
+
+if [[ -n "${OFFLINE:-}" ]]; then
+  MODE="offline"
+fi
+
+echo "Running setup in $MODE mode"
+
+function install_node() {
+  if ! command -v node >/dev/null; then
+    echo "Node.js not found. Installing..."
+    apt-get update
+    apt-get install -y nodejs npm
+  else
+    echo "Node.js already installed"
+  fi
+}
+
+function install_npm_deps() {
+  if [ "$MODE" = "online" ]; then
+    npm install
+  else
+    # Attempt offline install using cached packages
+    if npm ci --offline; then
+      echo "Dependencies installed from cache"
+    else
+      echo "Offline installation failed. Ensure npm cache is populated or run online setup first." >&2
+      exit 1
+    fi
+  fi
+}
+
+if [ "$MODE" = "online" ]; then
+  install_node
+fi
+
+install_npm_deps
+
+echo "Setup complete"


### PR DESCRIPTION
## Summary
- add `setup.sh` to configure environment
- document setup steps in README

## Testing
- `npm run lint` *(fails: EHOSTUNREACH)*
- `npm run format`